### PR TITLE
feat: add basic srs solver

### DIFF
--- a/engine/m01_srs/solver.py
+++ b/engine/m01_srs/solver.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from copy import deepcopy
+import random
+
+from typing import cast
+
+from .types import BatteryState, LifeSupportState, PowerplantState, SRSState
+from engine.lib.contracts import SNAPSHOT_SCHEMA, SRS_VERSION, Snapshot
+
+
+def make_initial_state() -> SRSState:
+    return {
+        "power": {
+            "plant": {"online": False, "output_kw": 0.0, "max_kw": 100.0},
+            "battery": {
+                "kw": 50.0,
+                "capacity_kw": 100.0,
+                "max_charge_kw": 20.0,
+                "max_discharge_kw": 20.0,
+            },
+        },
+        "life": {"o2_pct": 21.0, "temp_c": 22.0, "crew_awake": 0},
+        "env": {"ship_temp_c": 22.0},
+    }
+
+
+def _clamp(value: float, lo: float, hi: float) -> float:
+    return max(lo, min(hi, value))
+
+
+def tick(state: SRSState, dt_s: float, *, rng: random.Random) -> SRSState:
+    new_state: SRSState = deepcopy(state)
+
+    plant: PowerplantState = new_state["power"]["plant"]
+    battery: BatteryState = new_state["power"]["battery"]
+    life: LifeSupportState = new_state["life"]
+    env = new_state["env"]
+
+    if plant["online"]:
+        plant["output_kw"] = _clamp(plant["output_kw"] + 10.0 * dt_s, 0.0, plant["max_kw"])
+    else:
+        plant["output_kw"] = 0.0
+
+    life_load_kw = 5.0 + 0.1 * float(life["crew_awake"])
+    net_kw = plant["output_kw"] - life_load_kw
+
+    if net_kw >= 0.0:
+        charge_kw = min(net_kw, battery["max_charge_kw"])
+        battery["kw"] = _clamp(battery["kw"] + charge_kw * dt_s, 0.0, battery["capacity_kw"])
+    else:
+        discharge_kw = min(-net_kw, battery["max_discharge_kw"])
+        battery["kw"] = _clamp(battery["kw"] - discharge_kw * dt_s, 0.0, battery["capacity_kw"])
+
+    life["o2_pct"] = _clamp(
+        life["o2_pct"] + (21.0 - life["o2_pct"]) * 0.1 * dt_s + rng.random() * 0.05 - 0.025,
+        0.0,
+        100.0,
+    )
+    life["temp_c"] = _clamp(
+        life["temp_c"] + (22.0 - life["temp_c"]) * 0.1 * dt_s + rng.random() * 0.05 - 0.025,
+        -50.0,
+        100.0,
+    )
+
+    env["ship_temp_c"] = _clamp(
+        env["ship_temp_c"] + (life["temp_c"] - env["ship_temp_c"]) * 0.1 * dt_s,
+        -50.0,
+        100.0,
+    )
+
+    return new_state
+
+
+def build_snapshot(state: SRSState, tick_idx: int, ts_ms: int) -> Snapshot:
+    return {
+        "meta": {
+            "ts_ms": ts_ms,
+            "tick": tick_idx,
+            "schema": SNAPSHOT_SCHEMA,
+            "version": SRS_VERSION,
+        },
+        "state": cast(dict[str, object], state),
+    }

--- a/engine/m01_srs/types.py
+++ b/engine/m01_srs/types.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from typing import TypedDict
+
+
+class PowerplantState(TypedDict):
+    """State of the powerplant."""
+
+    online: bool
+    output_kw: float
+    max_kw: float
+
+
+class BatteryState(TypedDict):
+    """Simple battery model."""
+
+    kw: float
+    capacity_kw: float
+    max_charge_kw: float
+    max_discharge_kw: float
+
+
+class LifeSupportState(TypedDict):
+    """Crew life support readings."""
+
+    o2_pct: float
+    temp_c: float
+    crew_awake: int
+
+
+class PowerState(TypedDict):
+    plant: PowerplantState
+    battery: BatteryState
+
+
+class EnvState(TypedDict):
+    ship_temp_c: float
+
+
+class SRSState(TypedDict):
+    power: PowerState
+    life: LifeSupportState
+    env: EnvState

--- a/engine/tests/test_srs_solver.py
+++ b/engine/tests/test_srs_solver.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import random
+
+from engine.m01_srs.solver import build_snapshot, make_initial_state, tick
+
+
+def test_tick_deterministic() -> None:
+    state = make_initial_state()
+    rng1 = random.Random(42)
+    rng2 = random.Random(42)
+    out1 = tick(state, 1.0, rng=rng1)
+    out2 = tick(state, 1.0, rng=rng2)
+    assert out1 == out2
+    assert state == make_initial_state()  # original untouched
+
+
+def test_battery_charge_discharge() -> None:
+    state = make_initial_state()
+    state["power"]["plant"]["online"] = False
+    rng = random.Random(1)
+    out = tick(state, 1.0, rng=rng)
+    assert out["power"]["battery"]["kw"] < state["power"]["battery"]["kw"]
+
+    state_on = make_initial_state()
+    state_on["power"]["plant"]["online"] = True
+    rng2 = random.Random(1)
+    out_on = tick(state_on, 1.0, rng=rng2)
+    assert out_on["power"]["battery"]["kw"] > state_on["power"]["battery"]["kw"]
+
+
+def test_build_snapshot_shape() -> None:
+    state = make_initial_state()
+    snap = build_snapshot(state, 3, 1234)
+    meta = snap["meta"]
+    assert meta["tick"] == 3
+    assert meta["ts_ms"] == 1234
+    assert "schema" in meta and "version" in meta
+    assert snap["state"] == state


### PR DESCRIPTION
## Summary
- scaffold SRS state types for power, battery, and life support
- implement deterministic SRS tick solver and snapshot builder
- add tests for solver determinism, battery behavior, and snapshot shape

## Testing
- `black engine/m01_srs/types.py engine/m01_srs/solver.py engine/tests/test_srs_solver.py`
- `ruff check engine/m01_srs/solver.py engine/m01_srs/types.py engine/tests/test_srs_solver.py`
- `mypy --strict engine/m01_srs/types.py engine/m01_srs/solver.py engine/tests/test_srs_solver.py`
- `pytest engine/tests/test_srs_solver.py -q`
- `pytest -q`

## Spec refs
- [M01_Modular_Design_Index_SRS_Spec_v0.md#L58-L62](docs/modules/M01_Modular_Design_Index_SRS_Spec_v0.md#L58-L62)
- [M07_Async_Snapshots_Event_Wiring_v1.md#L1-L8](docs/modules/M07_Async_Snapshots_Event_Wiring_v1.md#L1-L8)


------
https://chatgpt.com/codex/tasks/task_e_68c5f6afd15083298387b1b06e51e0ae