### PR TITLE
feat: add snapshot publisher and demo

### DIFF
--- a/engine/tests/test_snapshot_publisher.py
+++ b/engine/tests/test_snapshot_publisher.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import random
+from typing import cast
+
+from engine.lib.config import EngineConfig
+from engine.workers.snapshots import InMemorySnapshotBus, SnapshotPublisher
+
+
+class DummySolver:
+    """Simple solver adding ``dt_s`` to ``battery_kw`` each tick."""
+
+    def tick(
+        self, state: dict[str, object], dt_s: float, *, rng: random.Random
+    ) -> dict[str, object]:
+        battery = cast(float, state.get("battery_kw", 0.0)) + dt_s
+        return {"battery_kw": battery}
+
+
+def test_step_increments_and_publishes() -> None:
+    cfg = EngineConfig(tick_hz=2)
+    bus = InMemorySnapshotBus()
+    solver = DummySolver()
+    pub = SnapshotPublisher(solver, cfg, bus)
+
+    snap1 = pub.step(0)
+    assert snap1["meta"]["tick"] == 1
+    assert snap1["state"]["battery_kw"] == 0.5
+
+    snap2 = pub.step(500)
+    assert snap2["meta"]["tick"] == 2
+    assert snap2["state"]["battery_kw"] == 1.0
+
+    assert bus.get_latest() == snap2

--- a/engine/workers/snapshots.py
+++ b/engine/workers/snapshots.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+from engine.lib.config import EngineConfig
+from engine.lib.contracts import (
+    SNAPSHOT_SCHEMA,
+    SRS_VERSION,
+    Snapshot,
+    SnapshotSink,
+    SnapshotSource,
+    TickSolver,
+)
+from engine.lib.rng import seed_for
+
+
+class InMemorySnapshotBus(SnapshotSink, SnapshotSource):
+    """A minimal in-memory snapshot bus.
+
+    Stores only the latest snapshot published to it.
+    Thread safety is intentionally omitted for simplicity.
+    """
+
+    def __init__(self) -> None:
+        self._latest: Optional[Snapshot] = None
+
+    def publish(self, snap: Snapshot) -> None:
+        self._latest = snap
+
+    def get_latest(self) -> Optional[Snapshot]:
+        return self._latest
+
+
+@dataclass
+class SnapshotPublisher:
+    """Run a tick loop and publish snapshots to a bus."""
+
+    solver: TickSolver
+    cfg: EngineConfig
+    bus: SnapshotSink
+    tick_idx: int = 0
+    state: dict[str, object] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        self._dt_s = 1.0 / self.cfg.tick_hz
+        self._rng = seed_for(self.cfg.save_seed, "publisher")
+        # Initialize state via solver helper with dt=0
+        self.state = self.solver.tick({}, 0.0, rng=self._rng)
+
+    def step(self, now_ms: int) -> Snapshot:
+        """Advance one tick and publish the resulting snapshot."""
+        self.tick_idx += 1
+        self.state = self.solver.tick(self.state, self._dt_s, rng=self._rng)
+        snap: Snapshot = {
+            "meta": {
+                "ts_ms": now_ms,
+                "tick": self.tick_idx,
+                "schema": SNAPSHOT_SCHEMA,
+                "version": SRS_VERSION,
+            },
+            "state": self.state,
+        }
+        self.bus.publish(snap)
+        return snap

--- a/tools/run_publisher.py
+++ b/tools/run_publisher.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import json
+import random
+import time
+from typing import cast
+
+from engine.lib.config import EngineConfig
+from engine.workers.snapshots import InMemorySnapshotBus, SnapshotPublisher
+
+
+class DemoSolver:
+    """Deterministic solver incrementing ``battery_kw`` by ``dt_s``."""
+
+    def tick(
+        self, state: dict[str, object], dt_s: float, *, rng: random.Random
+    ) -> dict[str, object]:
+        battery = cast(float, state.get("battery_kw", 0.0)) + dt_s
+        return {"battery_kw": battery}
+
+
+def main() -> None:
+    cfg = EngineConfig(tick_hz=2)
+    bus = InMemorySnapshotBus()
+    solver = DemoSolver()
+    pub = SnapshotPublisher(solver, cfg, bus)
+
+    for _ in range(5):
+        now_ms = int(time.time() * 1000)
+        snap = pub.step(now_ms)
+        print(json.dumps(snap, separators=(",", ":")))
+        time.sleep(1 / cfg.tick_hz)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement in-memory snapshot bus
- add snapshot publisher that advances ticks and emits snapshots
- demo runner and tests for snapshot publisher

## Testing
- `ruff check engine/workers/snapshots.py engine/tests/test_snapshot_publisher.py tools/run_publisher.py`
- `black engine/tests/test_snapshot_publisher.py tools/run_publisher.py engine/workers/snapshots.py`
- `uv run mypy --strict .`
- `uv run pytest -q`
- `uv run python tools/run_publisher.py`

## Spec refs
- [M07 Async Simulation & Atomic Snapshots](docs/modules/M07_Async_Snapshots_Event_Wiring_v1.md#L3-L9)

------
https://chatgpt.com/codex/tasks/task_e_68c5f6bd22c48329b8d07bfa60ec1a2a