### PR TITLE
feat: add JSON save store

### DIFF
--- a/engine/m11_persist/__init__.py
+++ b/engine/m11_persist/__init__.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+from .json_store import JsonSaveStore, safe_name
+
+__all__ = ["JsonSaveStore", "safe_name"]

--- a/engine/m11_persist/json_store.py
+++ b/engine/m11_persist/json_store.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import json
+import os
+import re
+import tempfile
+from pathlib import Path
+from typing import cast
+
+from engine.lib.config import Paths
+from engine.lib.contracts import SaveStore, Snapshot
+
+_NAME_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+
+
+def safe_name(name: str) -> str:
+    """Validate that ``name`` only contains safe characters.
+
+    Allowed characters are ``[A-Za-z0-9_-]``. Any other character results in a
+    ``ValueError`` being raised.
+    """
+    if not _NAME_RE.fullmatch(name):
+        raise ValueError(f"invalid save name: {name!r}")
+    return name
+
+
+class JsonSaveStore(SaveStore):
+    """Minimal JSON-based persistence for :class:`Snapshot` objects.
+
+    Snapshots are stored inside :data:`Paths.saves_dir` using ``{name}.json``
+    filenames. Writes are performed atomically by first writing to a temporary
+    file in the target directory and then replacing the final path.
+    """
+
+    def __init__(self, paths: Paths) -> None:
+        self._dir = Path(paths.saves_dir)
+        self._dir.mkdir(parents=True, exist_ok=True)
+
+    def _path_for(self, name: str) -> Path:
+        safe_name(name)
+        return self._dir / f"{name}.json"
+
+    def save(self, snap: Snapshot, *, name: str) -> str:
+        path = self._path_for(name)
+        fd, tmp_path = tempfile.mkstemp(dir=self._dir, prefix=f".{name}.", suffix=".tmp")
+        try:
+            with os.fdopen(fd, "w") as tmp:
+                json.dump(snap, tmp)
+                tmp.flush()
+                os.fsync(tmp.fileno())
+            os.replace(tmp_path, path)
+        finally:
+            if os.path.exists(tmp_path):
+                os.remove(tmp_path)
+        return str(path)
+
+    def load(self, name: str) -> Snapshot:
+        path = self._path_for(name)
+        with path.open() as fh:
+            data = json.load(fh)
+        if not isinstance(data, dict) or "meta" not in data or "state" not in data:
+            raise ValueError("invalid snapshot")
+        return cast(Snapshot, data)

--- a/engine/tests/test_json_store.py
+++ b/engine/tests/test_json_store.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from engine.lib.config import Paths
+from engine.lib.contracts import SNAPSHOT_SCHEMA, SRS_VERSION, Snapshot
+from engine.m11_persist import JsonSaveStore
+
+
+@pytest.fixture
+def sample_snap() -> Snapshot:
+    return {
+        "meta": {
+            "ts_ms": 1,
+            "tick": 1,
+            "schema": SNAPSHOT_SCHEMA,
+            "version": SRS_VERSION,
+        },
+        "state": {"foo": "bar"},
+    }
+
+
+def test_save_and_load(tmp_path: Path, sample_snap: Snapshot) -> None:
+    paths = Paths(saves_dir=str(tmp_path / "saves"))
+    store = JsonSaveStore(paths)
+
+    store.save(sample_snap, name="alpha")
+    loaded = store.load("alpha")
+    assert loaded == sample_snap
+
+
+def test_invalid_name(tmp_path: Path, sample_snap: Snapshot) -> None:
+    store = JsonSaveStore(Paths(saves_dir=str(tmp_path)))
+
+    with pytest.raises(ValueError):
+        store.save(sample_snap, name="bad/name")
+    with pytest.raises(ValueError):
+        store.load("bad name")
+
+
+def test_missing_file(tmp_path: Path) -> None:
+    store = JsonSaveStore(Paths(saves_dir=str(tmp_path)))
+    with pytest.raises(FileNotFoundError):
+        store.load("does_not_exist")


### PR DESCRIPTION
## Summary
- add JsonSaveStore for snapshot persistence with safe file names and atomic writes
- test JSON save/load round trips and error cases

## Testing
- `ruff check engine/m11_persist/json_store.py engine/tests/test_json_store.py`
- `black engine/tests/test_json_store.py`
- `mypy --strict engine/m11_persist/json_store.py engine/tests/test_json_store.py`
- `pytest -q`

## Spec refs
- [M11 Persistence Save/Load](docs/modules/M11_Persistence_SaveLoad_v1.md#L11-L17)


------
https://chatgpt.com/codex/tasks/task_e_68c5f6cad2ec8329a94b47551f4e7964