### PR TITLE
feat: add read-only dashboard TUI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "structlog>=25.4.0",
     "typer>=0.17.4",
     "typing-extensions>=4.15.0",
+    "textual>=0.79.1",
 ]
 
 [tool.black]

--- a/tools/run_tui.py
+++ b/tools/run_tui.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import cast
+
+import typer
+
+from engine.lib.contracts import Snapshot, SnapshotSource
+from ui.core.provider import PollingSnapshotProvider
+from ui.windows.dashboard_tui import DashboardTUI
+
+
+class InMemorySnapshotBus:
+    """Simple in-memory bus implementing both source and sink."""
+
+    def __init__(self) -> None:
+        self._snap: Snapshot | None = None
+
+    def publish(self, snap: Snapshot) -> None:
+        self._snap = snap
+
+    def get_latest(self) -> Snapshot | None:
+        return self._snap
+
+
+BUS = InMemorySnapshotBus()
+
+
+class FileSnapshotSource:
+    def __init__(self, path: Path) -> None:
+        self._path = path
+        self._mtime = 0.0
+        self._snap: Snapshot | None = None
+
+    def get_latest(self) -> Snapshot | None:
+        try:
+            mtime = self._path.stat().st_mtime
+        except FileNotFoundError:
+            return self._snap
+        if mtime > self._mtime:
+            with self._path.open("r") as f:
+                self._snap = cast(Snapshot, json.load(f))
+            self._mtime = mtime
+        return self._snap
+
+
+def main(
+    from_bus: bool = typer.Option(False, "--from-bus", help="Use in-memory bus"),
+    from_file: Path | None = typer.Option(None, "--from-file", help="Read from snapshot file"),
+) -> None:
+    if from_bus == (from_file is not None):
+        raise typer.BadParameter("Choose exactly one snapshot source")
+
+    source: SnapshotSource
+    if from_bus:
+        source = BUS
+    else:
+        assert from_file is not None
+        source = FileSnapshotSource(from_file)
+
+    provider = PollingSnapshotProvider(source)
+    DashboardTUI(provider).run()
+
+
+if __name__ == "__main__":
+    typer.run(main)

--- a/ui/core/provider.py
+++ b/ui/core/provider.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import time
+
+from engine.lib.contracts import Snapshot, SnapshotSource
+
+
+class PollingSnapshotProvider:
+    """Cache snapshots from a source, polling at a fixed interval.
+
+    Consumers call :meth:`get_latest` to retrieve the most recent snapshot. The
+    underlying source is polled at most once per ``interval_ms`` to avoid
+    unnecessary work, in line with the snapshot pattern from M07 where
+    consumers only see *atomic* snapshots.
+    """
+
+    def __init__(self, source: SnapshotSource, interval_ms: int = 500) -> None:
+        self._source = source
+        self.interval_ms = interval_ms
+        self._cached: Snapshot | None = None
+        self._last_poll_ms = 0.0
+
+    def get_latest(self) -> Snapshot | None:
+        """Return the most recently cached snapshot.
+
+        The underlying source is polled if more than ``interval_ms`` has elapsed
+        since the last poll. Otherwise the previously cached snapshot is
+        returned.
+        """
+
+        now_ms = time.monotonic() * 1000
+        if now_ms - self._last_poll_ms >= self.interval_ms:
+            self._cached = self._source.get_latest()
+            self._last_poll_ms = now_ms
+        return self._cached

--- a/ui/tests/test_provider.py
+++ b/ui/tests/test_provider.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from engine.lib.contracts import Snapshot
+from ui.core.provider import PollingSnapshotProvider
+
+
+class DummySource:
+    def __init__(self, snap: Snapshot | None) -> None:
+        self._snap = snap
+        self.calls = 0
+
+    def get_latest(self) -> Snapshot | None:
+        self.calls += 1
+        return self._snap
+
+
+def test_provider_returns_snapshot() -> None:
+    snap: Snapshot = {
+        "meta": {"ts_ms": 1, "tick": 0, "schema": "starship.snap/v1", "version": "0.1.0"},
+        "state": {"power": {}, "life": {}, "env": {}},
+    }
+    src = DummySource(snap)
+    provider = PollingSnapshotProvider(src, interval_ms=1000)
+    assert provider.get_latest() is snap
+    assert provider.get_latest() is snap
+    assert src.calls == 1

--- a/ui/windows/dashboard_tui.py
+++ b/ui/windows/dashboard_tui.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from typing import cast
+
+from textual.app import App, ComposeResult
+from textual.widgets import Static
+
+from ui.core.provider import PollingSnapshotProvider
+
+
+class DashboardTUI(App[None]):
+    """Minimal dashboard displaying key snapshot fields."""
+
+    def __init__(self, provider: PollingSnapshotProvider) -> None:
+        super().__init__()
+        self._provider = provider
+        self._status = Static("Waiting for data...")
+        self._plant = Static()
+        self._battery = Static()
+        self._o2 = Static()
+        self._life_temp = Static()
+        self._ship_temp = Static()
+        self._tick = Static()
+
+    def compose(self) -> ComposeResult:
+        yield self._status
+        yield self._plant
+        yield self._battery
+        yield self._o2
+        yield self._life_temp
+        yield self._ship_temp
+        yield self._tick
+
+    def on_mount(self) -> None:
+        self.set_interval(self._provider.interval_ms / 1000, self._refresh)
+
+    def _refresh(self) -> None:
+        snap = self._provider.get_latest()
+        if snap is None:
+            self._status.update("Waiting for data...")
+            for widget in (
+                self._plant,
+                self._battery,
+                self._o2,
+                self._life_temp,
+                self._ship_temp,
+                self._tick,
+            ):
+                widget.update("")
+            return
+
+        self._status.update("")
+        state = snap["state"]
+        power = cast(dict[str, float], state.get("power", {}))
+        life = cast(dict[str, float], state.get("life", {}))
+        env = cast(dict[str, float], state.get("env", {}))
+
+        self._plant.update(f"Plant Output: {power.get('plant_output_kw', 0.0):.1f} kW")
+        self._battery.update(
+            "Battery: "
+            f"{power.get('battery_kw', 0.0):.1f} / "
+            f"{power.get('battery_capacity_kw', 0.0):.1f} kW"
+        )
+        self._o2.update(f"O2: {life.get('o2_pct', 0.0):.1f}%")
+        self._life_temp.update(f"Life Temp: {life.get('life_temp_c', 0.0):.1f} °C")
+        self._ship_temp.update(f"Ship Temp: {env.get('ship_temp_c', 0.0):.1f} °C")
+        self._tick.update(f"Tick: {snap['meta']['tick']}")


### PR DESCRIPTION
## Summary
- add polling snapshot provider
- render textual dashboard from snapshots
- provide run_tui tool with bus or file source

## Testing
- `ruff check ui/core/provider.py ui/tests/test_provider.py ui/windows/dashboard_tui.py tools/run_tui.py`
- `mypy --strict ui/core/provider.py ui/tests/test_provider.py ui/windows/dashboard_tui.py tools/run_tui.py`
- `pytest -q`

## Spec refs
- [M07 Async Simulation & Atomic Snapshots — v1](docs/modules/M07_Async_Snapshots_Event_Wiring_v1.md#L4-L9)
- [M07 Async Simulation & Atomic Snapshots — v1](docs/modules/M07_Async_Snapshots_Event_Wiring_v1.md#L27-L28)
- [M12 UI Architecture (Widget‑Driven Windows) v0](docs/modules/M12_UI_Architecture_Widget_Driven_Windows_v0.md#L39-L41)
- [M12 UI Architecture (Widget‑Driven Windows) v0](docs/modules/M12_UI_Architecture_Widget_Driven_Windows_v0.md#L121-L124)


------
https://chatgpt.com/codex/tasks/task_e_68c5f6d64ae483299cc1feaf184ac98f