### PR TITLE
Add integration smoke test and demo script

### DIFF
--- a/engine/tests/test_integration_smoke.py
+++ b/engine/tests/test_integration_smoke.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from engine.lib.config import EngineConfig, Paths
+import random
+from typing import cast
+
+from engine.m01_srs import solver as srs_solver
+from engine.m01_srs.types import SRSState
+from engine.m11_persist import JsonSaveStore
+from engine.workers.snapshots import InMemorySnapshotBus, SnapshotPublisher
+
+
+class SRSSolverWrapper:
+    """Adapter exposing ``tick`` from the SRS solver as a class."""
+
+    def tick(
+        self, state: dict[str, object], dt_s: float, *, rng: random.Random
+    ) -> dict[str, object]:
+        base: SRSState
+        if not state:
+            base = srs_solver.make_initial_state()
+        else:
+            base = cast(SRSState, state)
+        return cast(dict[str, object], srs_solver.tick(base, dt_s, rng=rng))
+
+
+def test_integration_smoke(tmp_path: Path) -> None:
+    cfg = EngineConfig(tick_hz=2)
+    bus = InMemorySnapshotBus()
+    solver = SRSSolverWrapper()
+    pub = SnapshotPublisher(solver, cfg, bus)
+
+    snap = None
+    for i in range(5):
+        snap = pub.step(i * 100)
+
+    assert snap is not None
+    assert snap["meta"]["tick"] == 5
+    assert bus.get_latest() == snap
+
+    store = JsonSaveStore(Paths(saves_dir=str(tmp_path)))
+    store.save(snap, name="final")
+    loaded = store.load("final")
+    assert loaded == snap

--- a/tools/demo_all.py
+++ b/tools/demo_all.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import random
+import time
+from pathlib import Path
+from typing import cast
+
+import typer
+
+from engine.lib.config import EngineConfig, Paths
+from engine.lib.contracts import Snapshot
+from engine.m11_persist import JsonSaveStore
+from engine.workers.snapshots import InMemorySnapshotBus, SnapshotPublisher
+from ui.core.provider import PollingSnapshotProvider
+from ui.windows.dashboard_tui import DashboardTUI
+
+
+class DemoSolver:
+    """Produce sample data for the dashboard."""
+
+    def tick(
+        self, state: dict[str, object], dt_s: float, *, rng: random.Random
+    ) -> dict[str, object]:
+        power = cast(dict[str, float], state.get("power", {}))
+        life = cast(dict[str, float], state.get("life", {}))
+        env = cast(dict[str, float], state.get("env", {}))
+
+        plant_output_kw = power.get("plant_output_kw", 0.0) + 1.0 * dt_s
+        battery_kw = power.get("battery_kw", 50.0) + (plant_output_kw - 5.0) * dt_s
+        battery_capacity_kw = power.get("battery_capacity_kw", 100.0)
+
+        o2_pct = life.get("o2_pct", 21.0) + rng.random() * 0.1 - 0.05
+        life_temp_c = life.get("life_temp_c", 22.0) + rng.random() * 0.1 - 0.05
+        ship_temp_c = (
+            env.get("ship_temp_c", 22.0) + (life_temp_c - env.get("ship_temp_c", 22.0)) * 0.1 * dt_s
+        )
+
+        return {
+            "power": {
+                "plant_output_kw": plant_output_kw,
+                "battery_kw": battery_kw,
+                "battery_capacity_kw": battery_capacity_kw,
+            },
+            "life": {"o2_pct": o2_pct, "life_temp_c": life_temp_c},
+            "env": {"ship_temp_c": ship_temp_c},
+        }
+
+
+app = typer.Typer()
+
+
+@app.command()
+def main(
+    steps: int = typer.Option(10, "--steps", help="Number of steps to run"),
+    save: Path | None = typer.Option(None, "--save", help="Optional snapshot save path"),
+) -> None:
+    cfg = EngineConfig(tick_hz=2)
+    bus = InMemorySnapshotBus()
+    solver = DemoSolver()
+    pub = SnapshotPublisher(solver, cfg, bus)
+
+    snap: Snapshot | None = None
+    for _ in range(steps):
+        now_ms = int(time.time() * 1000)
+        snap = pub.step(now_ms)
+        time.sleep(0.5)
+
+    if save is not None and snap is not None:
+        store = JsonSaveStore(Paths(saves_dir=str(save.parent)))
+        path = store.save(snap, name=save.stem)
+        print(path)
+
+    provider = PollingSnapshotProvider(bus)
+    DashboardTUI(provider).run()
+
+
+if __name__ == "__main__":
+    typer.run(main)


### PR DESCRIPTION
## Summary
- add smoke test for solver/publisher/bus/store wiring
- introduce demo script to run publisher, optionally save, then launch TUI

## Testing
- `uv run ruff check --fix .`
- `uv run black engine/tests/test_integration_smoke.py tools/demo_all.py`
- `uv run mypy --strict engine/tests/test_integration_smoke.py tools/demo_all.py`
- `uv run pytest -q`
- `uv run python tools/demo_all.py --save data/saves/integration.json` *(fails: terminal emulator crashed)*

## Spec refs
- [M07 Async Simulation & Atomic Snapshots v1](docs/modules/M07_Async_Snapshots_Event_Wiring_v1.md#L4-L9)
- [M11 Persistence Save/Load v1](docs/modules/M11_Persistence_SaveLoad_v1.md#L14-L18)
- [M12 UI Architecture v0](docs/modules/M12_UI_Architecture_Widget_Driven_Windows_v0.md#L121-L124)

------
https://chatgpt.com/codex/tasks/task_e_68c5fc5bcaac832994fc9f78e99280e2