### PR TITLE
feat(ui): add dashboard panels

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "typer>=0.17.4",
     "typing-extensions>=4.15.0",
     "textual>=0.79.1",
+    "PySide6>=6.9.2",
 ]
 
 [tool.black]

--- a/ui/core/registry.py
+++ b/ui/core/registry.py
@@ -1,0 +1,41 @@
+"""Widget registry mapping ids to builder functions.
+
+This registry allows containers to construct widgets by identifier, keeping
+layout concerns separate from widget implementations (M12).
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Dict, List
+
+from ui.widgets.battery_panel import build as build_battery
+from ui.widgets.life_panel import build as build_life
+from ui.widgets.power_panel import build as build_power
+
+from .contracts import Widget
+
+WidgetBuilder = Callable[[], Widget]
+
+_REGISTRY: Dict[str, WidgetBuilder] = {}
+
+
+def register(widget_id: str, builder: WidgetBuilder) -> None:
+    """Register ``builder`` under ``widget_id``."""
+    _REGISTRY[widget_id] = builder
+
+
+def build(widget_id: str) -> Widget | None:
+    """Construct a widget by ``widget_id`` if registered."""
+    factory = _REGISTRY.get(widget_id)
+    return factory() if factory else None
+
+
+def ids() -> List[str]:
+    """Return a sorted list of registered widget IDs."""
+    return sorted(_REGISTRY)
+
+
+# Register built-in widgets
+register("power", build_power)
+register("battery", build_battery)
+register("life", build_life)

--- a/ui/tests/test_panels.py
+++ b/ui/tests/test_panels.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import pytest
+from PySide6.QtWidgets import QApplication  # type: ignore[import-not-found]
+
+from ui.core.contracts import BatteryVM, LifeVM, PowerVM
+from ui.widgets.battery_panel import BatteryPanel
+from ui.widgets.life_panel import LifePanel
+from ui.widgets.power_panel import PowerPanel
+
+
+@pytest.fixture(scope="module")
+def app() -> QApplication:
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication([])
+    return app
+
+
+def test_power_panel_updates_labels(app: QApplication) -> None:
+    panel = PowerPanel()
+    vm: PowerVM = {"plant_kw": 42.0, "plant_max_kw": 100.0}
+    panel.set_view(vm)
+    assert panel._output.text() == "Output: 42.0 kW"
+    assert panel._capacity.text() == "Capacity: 100.0 kW"
+
+
+def test_battery_panel_updates_labels(app: QApplication) -> None:
+    panel = BatteryPanel()
+    vm: BatteryVM = {"kw": 10.5, "capacity_kw": 50.25}
+    panel.set_view(vm)
+    assert panel._charge.text() == "Charge: 10.5 kW"
+    assert panel._capacity.text() == "Capacity: 50.2 kW"
+
+
+def test_life_panel_updates_labels(app: QApplication) -> None:
+    panel = LifePanel()
+    vm: LifeVM = {
+        "o2_pct": 21.0,
+        "life_temp_c": 22.25,
+        "ship_temp_c": 20.75,
+        "crew_awake": 4,
+    }
+    panel.set_view(vm)
+    assert panel._o2.text() == "O2: 21.0%"
+    assert panel._life_temp.text() == "Life Temp: 22.2 °C"
+    assert panel._ship_temp.text() == "Ship Temp: 20.8 °C"
+    assert panel._crew.text() == "Crew Awake: 4"

--- a/ui/widgets/battery_panel.py
+++ b/ui/widgets/battery_panel.py
@@ -1,0 +1,52 @@
+"""Simple battery status panel."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ui.core.contracts import BatteryVM, Widget
+
+if TYPE_CHECKING:
+
+    class QWidget:  # pragma: no cover - typing stub
+        def setLayout(self, layout: "QVBoxLayout") -> None: ...
+
+    class QLabel(QWidget):  # pragma: no cover - typing stub
+        def __init__(self, text: str = "") -> None: ...
+
+        def setText(self, text: str) -> None: ...
+
+        def text(self) -> str: ...
+
+    class QVBoxLayout:  # pragma: no cover - typing stub
+        def addWidget(self, widget: QWidget) -> None: ...
+
+else:  # pragma: no cover
+    from PySide6.QtWidgets import QLabel, QVBoxLayout, QWidget  # type: ignore[import-not-found]
+
+
+class BatteryPanel(QWidget):
+    """Display current battery charge and capacity."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._charge = QLabel("Charge: 0.0 kW")
+        self._capacity = QLabel("Capacity: 0.0 kW")
+        layout = QVBoxLayout()
+        layout.addWidget(self._charge)
+        layout.addWidget(self._capacity)
+        self.setLayout(layout)
+
+    def name(self) -> str:
+        return "Battery"
+
+    def set_view(self, vm: BatteryVM) -> None:
+        self._charge.setText(f"Charge: {vm['kw']:.1f} kW")
+        self._capacity.setText(f"Capacity: {vm['capacity_kw']:.1f} kW")
+
+
+def build() -> Widget:
+    """Factory used by the registry."""
+    from typing import cast
+
+    return cast(Widget, BatteryPanel())

--- a/ui/widgets/life_panel.py
+++ b/ui/widgets/life_panel.py
@@ -1,0 +1,58 @@
+"""Simple life-support status panel."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ui.core.contracts import LifeVM, Widget
+
+if TYPE_CHECKING:
+
+    class QWidget:  # pragma: no cover - typing stub
+        def setLayout(self, layout: "QVBoxLayout") -> None: ...
+
+    class QLabel(QWidget):  # pragma: no cover - typing stub
+        def __init__(self, text: str = "") -> None: ...
+
+        def setText(self, text: str) -> None: ...
+
+        def text(self) -> str: ...
+
+    class QVBoxLayout:  # pragma: no cover - typing stub
+        def addWidget(self, widget: QWidget) -> None: ...
+
+else:  # pragma: no cover
+    from PySide6.QtWidgets import QLabel, QVBoxLayout, QWidget  # type: ignore[import-not-found]
+
+
+class LifePanel(QWidget):
+    """Display life-support metrics."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._o2 = QLabel("O2: 0.0%")
+        self._life_temp = QLabel("Life Temp: 0.0 °C")
+        self._ship_temp = QLabel("Ship Temp: 0.0 °C")
+        self._crew = QLabel("Crew Awake: 0")
+        layout = QVBoxLayout()
+        layout.addWidget(self._o2)
+        layout.addWidget(self._life_temp)
+        layout.addWidget(self._ship_temp)
+        layout.addWidget(self._crew)
+        self.setLayout(layout)
+
+    def name(self) -> str:
+        return "Life"
+
+    def set_view(self, vm: LifeVM) -> None:
+        self._o2.setText(f"O2: {vm['o2_pct']:.1f}%")
+        self._life_temp.setText(f"Life Temp: {vm['life_temp_c']:.1f} °C")
+        self._ship_temp.setText(f"Ship Temp: {vm['ship_temp_c']:.1f} °C")
+        self._crew.setText(f"Crew Awake: {vm['crew_awake']}")
+
+
+def build() -> Widget:
+    """Factory used by the registry."""
+    from typing import cast
+
+    return cast(Widget, LifePanel())

--- a/ui/widgets/power_panel.py
+++ b/ui/widgets/power_panel.py
@@ -1,0 +1,52 @@
+"""Simple power status panel."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ui.core.contracts import PowerVM, Widget
+
+if TYPE_CHECKING:
+
+    class QWidget:  # pragma: no cover - typing stub
+        def setLayout(self, layout: "QVBoxLayout") -> None: ...
+
+    class QLabel(QWidget):  # pragma: no cover - typing stub
+        def __init__(self, text: str = "") -> None: ...
+
+        def setText(self, text: str) -> None: ...
+
+        def text(self) -> str: ...
+
+    class QVBoxLayout:  # pragma: no cover - typing stub
+        def addWidget(self, widget: QWidget) -> None: ...
+
+else:  # pragma: no cover
+    from PySide6.QtWidgets import QLabel, QVBoxLayout, QWidget  # type: ignore[import-not-found]
+
+
+class PowerPanel(QWidget):
+    """Display current and maximum power plant output."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._output = QLabel("Output: 0.0 kW")
+        self._capacity = QLabel("Capacity: 0.0 kW")
+        layout = QVBoxLayout()
+        layout.addWidget(self._output)
+        layout.addWidget(self._capacity)
+        self.setLayout(layout)
+
+    def name(self) -> str:
+        return "Power"
+
+    def set_view(self, vm: PowerVM) -> None:
+        self._output.setText(f"Output: {vm['plant_kw']:.1f} kW")
+        self._capacity.setText(f"Capacity: {vm['plant_max_kw']:.1f} kW")
+
+
+def build() -> Widget:
+    """Factory used by the registry."""
+    from typing import cast
+
+    return cast(Widget, PowerPanel())

--- a/uv.lock
+++ b/uv.lock
@@ -136,6 +136,18 @@ wheels = [
 ]
 
 [[package]]
+name = "linkify-it-py"
+version = "2.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "uc-micro-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2a/ae/bb56c6828e4797ba5a4821eec7c43b8bf40f69cda4d4f5f8c8a2810ec96a/linkify-it-py-2.0.3.tar.gz", hash = "sha256:68cda27e162e9215c17d786649d1da0021a451bdc436ef9e0fa0ba5234b9b048", size = 27946, upload-time = "2024-02-04T14:48:04.179Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/1e/b832de447dee8b582cac175871d2f6c3d5077cc56d5575cadba1fd1cccfa/linkify_it_py-2.0.3-py3-none-any.whl", hash = "sha256:6bcbc417b0ac14323382aef5c5192c0075bf8a9d6b41820a2b66371eac6b6d79", size = 19820, upload-time = "2024-02-04T14:48:02.496Z" },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -145,6 +157,26 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[package.optional-dependencies]
+linkify = [
+    { name = "linkify-it-py" },
+]
+plugins = [
+    { name = "mdit-py-plugins" },
+]
+
+[[package]]
+name = "mdit-py-plugins"
+version = "0.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b2/fd/a756d36c0bfba5f6e39a1cdbdbfdd448dc02692467d83816dff4592a1ebc/mdit_py_plugins-0.5.0.tar.gz", hash = "sha256:f4918cb50119f50446560513a8e311d574ff6aaed72606ddae6d35716fe809c6", size = 44655, upload-time = "2025-08-11T07:25:49.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/86/dd6e5db36df29e76c7a7699123569a4a18c1623ce68d826ed96c62643cae/mdit_py_plugins-0.5.0-py3-none-any.whl", hash = "sha256:07a08422fc1936a5d26d146759e9155ea466e842f5ab2f7d2266dd084c8dab1f", size = 57205, upload-time = "2025-08-11T07:25:47.597Z" },
 ]
 
 [[package]]
@@ -325,6 +357,54 @@ wheels = [
 ]
 
 [[package]]
+name = "pyside6"
+version = "6.9.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyside6-addons" },
+    { name = "pyside6-essentials" },
+    { name = "shiboken6" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/42/43577413bd5ab26f5f21e7a43c9396aac158a5d01900c87e4609c0e96278/pyside6-6.9.2-cp39-abi3-macosx_12_0_universal2.whl", hash = "sha256:71245c76bfbe5c41794ffd8546730ec7cc869d4bbe68535639e026e4ef8a7714", size = 558102, upload-time = "2025-08-26T07:52:57.302Z" },
+    { url = "https://files.pythonhosted.org/packages/12/df/cb84f802df3dcc1d196d2f9f37dbb8227761826f936987c9386b8ae1ffcc/pyside6-6.9.2-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:64a9e2146e207d858e00226f68d7c1b4ab332954742a00dcabb721bb9e4aa0cd", size = 558243, upload-time = "2025-08-26T07:52:59.272Z" },
+    { url = "https://files.pythonhosted.org/packages/94/2d/715db9da437b4632d06e2c4718aee9937760b84cf36c23d5441989e581b0/pyside6-6.9.2-cp39-abi3-manylinux_2_39_aarch64.whl", hash = "sha256:a78fad16241a1f2ed0fa0098cf3d621f591fc75b4badb7f3fa3959c9d861c806", size = 558245, upload-time = "2025-08-26T07:53:00.838Z" },
+    { url = "https://files.pythonhosted.org/packages/59/90/2e75cbff0e17f16b83d2b7e8434ae9175cae8d6ff816c9b56d307cf53c86/pyside6-6.9.2-cp39-abi3-win_amd64.whl", hash = "sha256:d1afbf48f9a5612b9ee2dc7c384c1a65c08b5830ba5e7d01f66d82678e5459df", size = 564604, upload-time = "2025-08-26T07:53:02.402Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/34/e3dd4e046673efcbcfbe0aa2760df06b2877739b8f4da60f0229379adebd/pyside6-6.9.2-cp39-abi3-win_arm64.whl", hash = "sha256:1499b1d7629ab92119118e2636b4ace836b25e457ddf01003fdca560560b8c0a", size = 401833, upload-time = "2025-08-26T07:53:03.742Z" },
+]
+
+[[package]]
+name = "pyside6-addons"
+version = "6.9.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyside6-essentials" },
+    { name = "shiboken6" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/39/a8f4a55001b6a0aaee042e706de2447f21c6dc2a610f3d3debb7d04db821/pyside6_addons-6.9.2-cp39-abi3-macosx_12_0_universal2.whl", hash = "sha256:7019fdcc0059626eb1608b361371f4dc8cb7f2d02f066908fd460739ff5a07cd", size = 316693692, upload-time = "2025-08-26T07:33:31.529Z" },
+    { url = "https://files.pythonhosted.org/packages/14/48/0b16e9dabd4cafe02d59531832bc30b6f0e14c92076e90dd02379d365cb2/pyside6_addons-6.9.2-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:24350e5415317f269e743d1f7b4933fe5f59d90894aa067676c9ce6bfe9e7988", size = 166984613, upload-time = "2025-08-26T07:33:47.569Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/55/dc42a73387379bae82f921b7659cd2006ec0e80f7052f83ddc07e9eb9cca/pyside6_addons-6.9.2-cp39-abi3-manylinux_2_39_aarch64.whl", hash = "sha256:af8dee517de8d336735a6543f7dd496eb580e852c14b4d2304b890e2a29de499", size = 162908466, upload-time = "2025-08-26T07:39:49.331Z" },
+    { url = "https://files.pythonhosted.org/packages/14/fa/396a2e86230c493b565e2dc89dc64e4b1c63582ac69afe77b693c3817a53/pyside6_addons-6.9.2-cp39-abi3-win_amd64.whl", hash = "sha256:98d2413904ee4b2b754b077af7875fa6ec08468c01a6628a2c9c3d2cece4874f", size = 160216647, upload-time = "2025-08-26T07:42:18.903Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/fe/25f61259f1d5ec4648c9f6d2abd8e2cba2188f10735a57abafda719958e5/pyside6_addons-6.9.2-cp39-abi3-win_arm64.whl", hash = "sha256:b430cae782ff1a99fb95868043557f22c31b30c94afb9cf73278584e220a2ab6", size = 27126649, upload-time = "2025-08-26T07:42:37.696Z" },
+]
+
+[[package]]
+name = "pyside6-essentials"
+version = "6.9.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "shiboken6" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/21/41960c03721a99e7be99a96ebb8570bdfd6f76f512b5d09074365e27ce28/pyside6_essentials-6.9.2-cp39-abi3-macosx_12_0_universal2.whl", hash = "sha256:713eb8dcbb016ff10e6fca129c1bf2a0fd8cfac979e689264e0be3b332f9398e", size = 133092348, upload-time = "2025-08-26T07:43:57.231Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/02/e38ff18f3d2d8d3071aa6823031aad6089267aa4668181db65ce9948bfc0/pyside6_essentials-6.9.2-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:84b8ca4fa56506e2848bdb4c7a0851a5e7adcb916bef9bce25ce2eeb6c7002cc", size = 96569791, upload-time = "2025-08-26T07:44:41.392Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a1/1203d4db6919b42a937d9ac5ddb84b20ea42eb119f7c1ddeb77cb8fdb00c/pyside6_essentials-6.9.2-cp39-abi3-manylinux_2_39_aarch64.whl", hash = "sha256:d0f701503974bd51b408966539aa6956f3d8536e547ea8002fbfb3d77796bbc3", size = 94311809, upload-time = "2025-08-26T07:46:44.924Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/e3/3b3e869d3e332b6db93f6f64fac3b12f5c48b84f03f2aa50ee5c044ec0de/pyside6_essentials-6.9.2-cp39-abi3-win_amd64.whl", hash = "sha256:b2f746f795138ac63eb173f9850a6db293461a1b6ce22cf6dafac7d194a38951", size = 72624566, upload-time = "2025-08-26T07:48:04.64Z" },
+    { url = "https://files.pythonhosted.org/packages/91/70/db78afc8b60b2e53f99145bde2f644cca43924a4dd869ffe664e0792730a/pyside6_essentials-6.9.2-cp39-abi3-win_arm64.whl", hash = "sha256:ecd7b5cd9e271f397fb89a6357f4ec301d8163e50869c6c557f9ccc6bed42789", size = 49561720, upload-time = "2025-08-26T07:49:43.708Z" },
+]
+
+[[package]]
 name = "pytest"
 version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
@@ -427,6 +507,18 @@ wheels = [
 ]
 
 [[package]]
+name = "shiboken6"
+version = "6.9.2"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/1e/62a8757aa0aa8d5dbf876f6cb6f652a60be9852e7911b59269dd983a7fb5/shiboken6-6.9.2-cp39-abi3-macosx_12_0_universal2.whl", hash = "sha256:8bb1c4326330e53adeac98bfd9dcf57f5173a50318a180938dcc4825d9ca38da", size = 406337, upload-time = "2025-08-26T07:52:39.614Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/bb/72a8ed0f0542d9ea935f385b396ee6a4bbd94749c817cbf2be34e80a16d3/shiboken6-6.9.2-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:3b54c0a12ea1b03b9dc5dcfb603c366e957dc75341bf7cb1cc436d0d848308ee", size = 206733, upload-time = "2025-08-26T07:52:41.768Z" },
+    { url = "https://files.pythonhosted.org/packages/52/c4/09e902f5612a509cef2c8712c516e4fe44f3a1ae9fcd8921baddb5e6bae4/shiboken6-6.9.2-cp39-abi3-manylinux_2_39_aarch64.whl", hash = "sha256:a5f5985938f5acb604c23536a0ff2efb3cccb77d23da91fbaff8fd8ded3dceb4", size = 202784, upload-time = "2025-08-26T07:52:43.172Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/ea/a56b094a4bf6facf89f52f58e83684e168b1be08c14feb8b99969f3d4189/shiboken6-6.9.2-cp39-abi3-win_amd64.whl", hash = "sha256:68c33d565cd4732be762d19ff67dfc53763256bac413d392aa8598b524980bc4", size = 1152089, upload-time = "2025-08-26T07:52:45.162Z" },
+    { url = "https://files.pythonhosted.org/packages/48/64/562a527fc55fbf41fa70dae735929988215505cb5ec0809fb0aef921d4a0/shiboken6-6.9.2-cp39-abi3-win_arm64.whl", hash = "sha256:c5b827797b3d89d9b9a3753371ff533fcd4afc4531ca51a7c696952132098054", size = 1708948, upload-time = "2025-08-26T07:52:48.016Z" },
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -450,7 +542,9 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },
+    { name = "pyside6" },
     { name = "structlog" },
+    { name = "textual" },
     { name = "typer" },
     { name = "typing-extensions" },
 ]
@@ -469,7 +563,9 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "pydantic", specifier = ">=2.11.9" },
+    { name = "pyside6", specifier = ">=6.9.2" },
     { name = "structlog", specifier = ">=25.4.0" },
+    { name = "textual", specifier = ">=0.79.1" },
     { name = "typer", specifier = ">=0.17.4" },
     { name = "typing-extensions", specifier = ">=4.15.0" },
 ]
@@ -492,6 +588,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/79/b9/6e672db4fec07349e7a8a8172c1a6ae235c58679ca29c3f86a61b5e59ff3/structlog-25.4.0.tar.gz", hash = "sha256:186cd1b0a8ae762e29417095664adf1d6a31702160a46dacb7796ea82f7409e4", size = 1369138, upload-time = "2025-06-02T08:21:12.971Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/4a/97ee6973e3a73c74c8120d59829c3861ea52210667ec3e7a16045c62b64d/structlog-25.4.0-py3-none-any.whl", hash = "sha256:fe809ff5c27e557d14e613f45ca441aabda051d119ee5a0102aaba6ce40eed2c", size = 68720, upload-time = "2025-06-02T08:21:11.43Z" },
+]
+
+[[package]]
+name = "textual"
+version = "6.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py", extra = ["linkify", "plugins"] },
+    { name = "platformdirs" },
+    { name = "pygments" },
+    { name = "rich" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/da/44/4b524b2f06e0fa6c4ede56a4e9af5edd5f3f83cf2eea5cb4fd0ce5bbe063/textual-6.1.0.tar.gz", hash = "sha256:cc89826ca2146c645563259320ca4ddc75d183c77afb7d58acdd46849df9144d", size = 1564786, upload-time = "2025-09-02T11:42:34.655Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/43/f91e041f239b54399310a99041faf33beae9a6e628671471d0fcd6276af4/textual-6.1.0-py3-none-any.whl", hash = "sha256:a3f5e6710404fcdc6385385db894699282dccf2ad50103cebc677403c1baadd5", size = 707840, upload-time = "2025-09-02T11:42:32.746Z" },
 ]
 
 [[package]]
@@ -528,6 +640,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f8/b1/0c11f5058406b3af7609f121aaa6b609744687f1d158b3c3a5bf4cc94238/typing_inspection-0.4.1.tar.gz", hash = "sha256:6ae134cc0203c33377d43188d4064e9b357dba58cff3185f22924610e70a9d28", size = 75726, upload-time = "2025-05-21T18:55:23.885Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/17/69/cd203477f944c353c31bade965f880aa1061fd6bf05ded0726ca845b6ff7/typing_inspection-0.4.1-py3-none-any.whl", hash = "sha256:389055682238f53b04f7badcb49b989835495a96700ced5dab2d8feae4b26f51", size = 14552, upload-time = "2025-05-21T18:55:22.152Z" },
+]
+
+[[package]]
+name = "uc-micro-py"
+version = "1.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/91/7a/146a99696aee0609e3712f2b44c6274566bc368dfe8375191278045186b8/uc-micro-py-1.0.3.tar.gz", hash = "sha256:d321b92cff673ec58027c04015fcaa8bb1e005478643ff4a500882eaab88c48a", size = 6043, upload-time = "2024-02-09T16:52:01.654Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/87/1f677586e8ac487e29672e4b17455758fce261de06a0d086167bb760361a/uc_micro_py-1.0.3-py3-none-any.whl", hash = "sha256:db1dffff340817673d7b466ec86114a9dc0e9d4d9b5ba229d9d60e5c12600cd5", size = 6229, upload-time = "2024-02-09T16:52:00.371Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- implement power, battery, and life panels using simple QLabel layouts
- register dashboard widgets through a central registry and expose build helpers
- add PySide6 dependency and tests for VM label updates

## Testing
- `ruff check ui/core/registry.py ui/widgets/power_panel.py ui/widgets/battery_panel.py ui/widgets/life_panel.py ui/tests/test_panels.py`
- `python -m black ui/widgets/power_panel.py ui/widgets/battery_panel.py ui/widgets/life_panel.py ui/tests/test_panels.py ui/core/registry.py`
- `mypy --strict ui/core/registry.py ui/widgets/power_panel.py ui/widgets/battery_panel.py ui/widgets/life_panel.py ui/tests/test_panels.py`
- `QT_QPA_PLATFORM=offscreen uv run pytest -q`

## Spec refs
- `docs/modules/M12_UI_Architecture_Widget_Driven_Windows_v0.md` lines 6-7, 44-47
- `docs/modules/M13_Engineering_Conventions_Project_Standards_v0.md` line 7, lines 126-127

------
https://chatgpt.com/codex/tasks/task_e_68c6067a7b348329bf0670e4e9ca7795