### PR TITLE
Add UI snapshot save/load actions

### DIFF
--- a/ui/core/actions.py
+++ b/ui/core/actions.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from typing import Dict, cast
+
+from engine.lib.contracts import SaveStore, Snapshot
+from engine.m11_persist import safe_name
+
+from .contracts import SnapshotProvider
+
+
+def save_last_snapshot(store: SaveStore, provider: SnapshotProvider, name: str) -> str:
+    """Persist the most recent snapshot using *store* under *name*.
+
+    ``provider`` supplies the latest snapshot (M07) while ``store`` performs the
+    atomic JSON save (M11). ``name`` must satisfy :func:`safe_name` rules.
+
+    Returns the path written to or raises ``ValueError`` if no snapshot is
+    available or the name is invalid.
+    """
+
+    safe_name(name)
+    snap = provider.get_latest()
+    if snap is None:
+        raise ValueError("no snapshot available")
+    return store.save(cast(Snapshot, snap), name=name)
+
+
+def load_snapshot(store: SaveStore, name: str) -> Dict[str, object]:
+    """Load and return a previously saved snapshot from *store*.
+
+    ``name`` must satisfy :func:`safe_name` rules. ``FileNotFoundError`` is
+    propagated if the snapshot does not exist.
+    """
+
+    safe_name(name)
+    return cast(Dict[str, object], store.load(name))

--- a/ui/tests/test_actions.py
+++ b/ui/tests/test_actions.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from typing import cast
+
+import pytest
+
+from engine.lib.contracts import SNAPSHOT_SCHEMA, SRS_VERSION, SaveStore, Snapshot
+from engine.m11_persist import safe_name
+from ui.core.actions import load_snapshot, save_last_snapshot
+from ui.core.contracts import SnapshotProvider
+
+
+class FakeStore(SaveStore):
+    def __init__(self) -> None:
+        self.saved: dict[str, Snapshot] = {}
+
+    def save(self, snap: Snapshot, *, name: str) -> str:
+        safe_name(name)
+        self.saved[name] = snap
+        return f"/fake/{name}.json"
+
+    def load(self, name: str) -> Snapshot:
+        safe_name(name)
+        if name not in self.saved:
+            raise FileNotFoundError(name)
+        return self.saved[name]
+
+
+class FakeProvider(SnapshotProvider):
+    def __init__(self, snap: Snapshot | None) -> None:
+        self._snap = snap
+
+    def get_latest(self) -> dict[str, object] | None:
+        return cast(dict[str, object], self._snap) if self._snap is not None else None
+
+
+@pytest.fixture
+def sample_snap() -> Snapshot:
+    return {
+        "meta": {
+            "ts_ms": 1,
+            "tick": 1,
+            "schema": SNAPSHOT_SCHEMA,
+            "version": SRS_VERSION,
+        },
+        "state": {},
+    }
+
+
+def test_save_returns_path(sample_snap: Snapshot) -> None:
+    store = FakeStore()
+    provider = FakeProvider(sample_snap)
+    path = save_last_snapshot(store, provider, "alpha")
+    assert path == "/fake/alpha.json"
+    assert store.saved["alpha"] == sample_snap
+
+
+def test_load_unknown_raises() -> None:
+    store = FakeStore()
+    with pytest.raises(FileNotFoundError):
+        load_snapshot(store, "missing")
+
+
+def test_no_snapshot_raises() -> None:
+    store = FakeStore()
+    provider = FakeProvider(None)
+    with pytest.raises(ValueError):
+        save_last_snapshot(store, provider, "alpha")
+
+
+def test_invalid_name_raises(sample_snap: Snapshot) -> None:
+    store = FakeStore()
+    provider = FakeProvider(sample_snap)
+    with pytest.raises(ValueError):
+        save_last_snapshot(store, provider, "bad/name")
+    with pytest.raises(ValueError):
+        load_snapshot(store, "bad name")

--- a/ui/windows/main_window.py
+++ b/ui/windows/main_window.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from engine.lib.contracts import SaveStore
+from ui.core.actions import load_snapshot, save_last_snapshot
+from ui.core.contracts import SnapshotProvider
+
+
+class MainWindow:
+    """Text-based main window stub with file menu actions."""
+
+    def __init__(self, store: SaveStore, provider: SnapshotProvider) -> None:
+        self._store = store
+        self._provider = provider
+
+    def save_last_snapshot_action(self) -> None:
+        name = input("Save snapshot as: ")
+        try:
+            path = save_last_snapshot(self._store, self._provider, name)
+        except Exception as exc:  # pragma: no cover - UI feedback
+            print(f"Save failed: {exc}")
+            return
+        print(f"Snapshot saved to {path}")
+
+    def load_snapshot_action(self) -> None:
+        name = input("Load snapshot name: ")
+        try:
+            snap = load_snapshot(self._store, name)
+        except Exception as exc:  # pragma: no cover - UI feedback
+            print(f"Load failed: {exc}")
+            return
+        print(f"Loaded snapshot: {name} (tick={snap.get('meta', {}).get('tick')})")


### PR DESCRIPTION
## Summary
- add `save_last_snapshot` and `load_snapshot` helpers
- wire main window menu actions for saving/loading snapshots
- cover save/load behaviors with unit tests

## Testing
- `ruff check ui/core/actions.py ui/windows/main_window.py ui/tests/test_actions.py --statistics`
- `mypy --strict ui/core/actions.py ui/windows/main_window.py ui/tests/test_actions.py`
- `uv run pytest -q`

## Spec refs
- [M07 Async Simulation & Atomic Snapshots](docs/modules/M07_Async_Snapshots_Event_Wiring_v1.md#L3-L9)
- [M11 Persistence Save/Load](docs/modules/M11_Persistence_SaveLoad_v1.md#L14-L18)


------
https://chatgpt.com/codex/tasks/task_e_68c606a468c48329bb32dec8ad3bd26f