### PR TITLE
Add autosave worker and CLI

### DIFF
--- a/engine/m01_srs/solver.py
+++ b/engine/m01_srs/solver.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
-from copy import deepcopy
 import random
-
+from copy import deepcopy
 from typing import cast
 
-from .types import BatteryState, LifeSupportState, PowerplantState, SRSState
 from engine.lib.contracts import SNAPSHOT_SCHEMA, SRS_VERSION, Snapshot
+
+from .types import BatteryState, LifeSupportState, PowerplantState, SRSState
 
 
 def make_initial_state() -> SRSState:

--- a/engine/tests/test_autosave.py
+++ b/engine/tests/test_autosave.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from engine.lib.config import Paths
+from engine.lib.contracts import Snapshot, SnapshotSource
+from engine.m11_persist import JsonSaveStore
+from engine.workers.autosave import AutoSaver
+
+
+class FakeSource(SnapshotSource):
+    def __init__(self) -> None:
+        self._tick = 0
+
+    def get_latest(self) -> Snapshot | None:
+        self._tick += 1
+        return {
+            "meta": {"ts_ms": 0, "tick": self._tick, "schema": "s", "version": "v"},
+            "state": {},
+        }
+
+
+def test_autosave_rotates(tmp_path: Path) -> None:
+    store = JsonSaveStore(Paths(saves_dir=str(tmp_path)))
+    saver = AutoSaver(FakeSource(), store, limit=3)
+
+    paths = []
+    for _ in range(5):
+        path = saver.run_once(0)
+        assert path is not None
+        paths.append(Path(path))
+
+    files = sorted(p.name for p in tmp_path.glob("autosave_*.json"))
+    assert files == ["autosave_0003.json", "autosave_0004.json", "autosave_0005.json"]
+    assert paths[-1].name == "autosave_0005.json"
+
+
+class EmptySource(SnapshotSource):
+    def get_latest(self) -> Snapshot | None:
+        return None
+
+
+def test_autosave_no_snapshot(tmp_path: Path) -> None:
+    store = JsonSaveStore(Paths(saves_dir=str(tmp_path)))
+    saver = AutoSaver(EmptySource(), store)
+    assert saver.run_once(0) is None
+    assert list(tmp_path.glob("*.json")) == []

--- a/engine/tests/test_integration_smoke.py
+++ b/engine/tests/test_integration_smoke.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
-from pathlib import Path
-
-from engine.lib.config import EngineConfig, Paths
 import random
+from pathlib import Path
 from typing import cast
 
+from engine.lib.config import EngineConfig, Paths
 from engine.m01_srs import solver as srs_solver
 from engine.m01_srs.types import SRSState
 from engine.m11_persist import JsonSaveStore

--- a/engine/workers/autosave.py
+++ b/engine/workers/autosave.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from engine.lib.contracts import SnapshotSource
+from engine.m11_persist import JsonSaveStore
+
+
+@dataclass
+class AutoSaver:
+    """Persist snapshots to disk with rotation."""
+
+    source: SnapshotSource
+    store: JsonSaveStore
+    prefix: str = "autosave_"
+    limit: int = 10
+
+    def run_once(self, now_ms: int) -> str | None:  # noqa: D401 - delegated
+        """Persist the latest snapshot if available."""
+        snap = self.source.get_latest()
+        if snap is None:
+            return None
+
+        tick = int(snap["meta"]["tick"])
+        name = f"{self.prefix}{tick:04d}"
+        path = self.store.save(snap, name=name)
+
+        save_dir = Path(self.store._dir)
+        existing = sorted(save_dir.glob(f"{self.prefix}*.json"))
+        if self.limit > 0 and len(existing) > self.limit:
+            for old in existing[: -self.limit]:
+                old.unlink(missing_ok=True)
+
+        return path

--- a/tools/run_autosave.py
+++ b/tools/run_autosave.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import argparse
+import random
+import time
+from typing import cast
+
+from engine.lib.config import EngineConfig, Paths
+from engine.m11_persist import JsonSaveStore
+from engine.workers.autosave import AutoSaver
+from engine.workers.snapshots import InMemorySnapshotBus, SnapshotPublisher
+
+
+class DemoSolver:
+    """Deterministic solver incrementing ``battery_kw`` by ``dt_s``."""
+
+    def tick(
+        self, state: dict[str, object], dt_s: float, *, rng: random.Random
+    ) -> dict[str, object]:
+        battery = cast(float, state.get("battery_kw", 0.0)) + dt_s
+        return {"battery_kw": battery}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--interval-s", type=float, default=1.0)
+    parser.add_argument("--limit", type=int, default=10)
+    parser.add_argument("--prefix", default="autosave_")
+    args = parser.parse_args()
+
+    cfg = EngineConfig()
+    bus = InMemorySnapshotBus()
+    solver = DemoSolver()
+    pub = SnapshotPublisher(solver, cfg, bus)
+    store = JsonSaveStore(Paths())
+    saver = AutoSaver(bus, store, prefix=args.prefix, limit=args.limit)
+
+    try:
+        while True:
+            now_ms = int(time.time() * 1000)
+            pub.step(now_ms)
+            path = saver.run_once(now_ms)
+            if path:
+                print(f"saved {path}")
+            time.sleep(args.interval_s)
+    except KeyboardInterrupt:
+        pass
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- persist latest snapshot to rotating JSON files
- expose `AutoSaver` worker and `run_autosave` CLI
- test autosave rotation and empty source cases

## Testing
- `uv run ruff check .`
- `uv run black --check engine/workers/autosave.py tools/run_autosave.py engine/tests/test_autosave.py engine/m01_srs/solver.py engine/tests/test_integration_smoke.py`
- `uv run mypy --strict engine tools`
- `uv run pytest`
- `uv run python tools/run_autosave.py --interval-s 2 --limit 3`

Spec refs:
- [M07](docs/modules/M07_Async_Snapshots_Event_Wiring_v1.md#L6-L16)
- [M11](docs/modules/M11_Persistence_SaveLoad_v1.md#L14-L17)


------
https://chatgpt.com/codex/tasks/task_e_68c606af84a483299a2f080d9fb3e481